### PR TITLE
Add user default currency retrieval to CurrencyConverter component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
 # CurrencyConverterComponent
 
+Salesforce Lightning Web Component (LWC) for converting amounts between active org currencies using Salesforce `CurrencyType.ConversionRate` values.
+
+## Screenshot
+
+![Component Example](./images/Screenshot%202026-04-22%20164836.png)
+
+## How the component works
+
+The UI and conversion logic are split across:
+
+- **LWC**: `force-app/main/default/lwc/currencyConverter`
+- **Apex service**: `force-app/main/default/classes/CurrencyConverterService.cls`
+
+### Runtime flow
+
+1. On load, the component calls `getActiveCurrencies()` to fetch active currencies.
+2. It then calls `getUserDefaultCurrencyIso()` to set the initial **From Currency** selection:
+  - If the user has a default currency (`DefaultCurrencyIsoCode`), it is used.
+  - If not, the org's default currency is used (falling back to `USD` if unavailable).
+3. Users enter:
+   - source currency (`From Currency`)
+   - amount (`Enter Amount`)
+   - target currency (`To Currency`)
+4. Clicking **Calculate** calls `convertCurrency(amount, fromIso, toIso)`.
+5. The result is shown in **Converted Amount** and can be copied with the copy icon.
+6. The swap icon swaps source and target currency selections.
+
+### Conversion formula
+
+Rates are treated as relative to the org base currency:
+
+```text
+baseAmount = amount / fromRate
+result     = baseAmount * toRate
+```
+
+Returned values are rounded to 2 decimal places.
+
+## Component behavior details
+
+- **Calculate button is disabled** until:
+  - amount is present
+  - amount is numeric and greater than 0
+  - both currencies are selected
+- **Errors**
+  - UI shows `Failed to load currencies.` if currency list retrieval fails.
+  - UI shows Apex error message when conversion fails.
+- **Loading**
+  - Spinner appears while conversion is in progress.
+- **Copy to clipboard**
+  - Copy icon copies converted value and briefly displays `Copied!`.
+- **Rate source**
+  - Uses configured Salesforce conversion rates, **not live market FX rates**.
+
+## Where the component can be used
+
+Defined in `currencyConverter.js-meta.xml`:
+
+- `lightning__AppPage`
+- `lightning__RecordPage`
+- `lightning__HomePage`
+- `lightning__UtilityBar`

--- a/force-app/main/default/classes/CurrencyConverterService.cls
+++ b/force-app/main/default/classes/CurrencyConverterService.cls
@@ -70,4 +70,22 @@ public with sharing class CurrencyConverterService {
         // Fallback to USD, as Organization.DefaultCurrencyIsoCode is not available
         return 'USD';
     }
+
+    /**
+     * Get the user's default currency ISO code, fallback to org default if not set
+     */
+    @AuraEnabled(cacheable=true)
+    public static String getUserDefaultCurrencyIso() {
+        // Try to get the user's currency (works in multi-currency orgs)
+        String userCurrency = null;
+        try {
+            userCurrency = [SELECT DefaultCurrencyIsoCode FROM User WHERE Id = :UserInfo.getUserId() LIMIT 1].DefaultCurrencyIsoCode;
+        } catch (Exception e) {
+            // Ignore and fallback
+        }
+        if (String.isNotBlank(userCurrency)) {
+            return userCurrency;
+        }
+        return getOrgDefaultCurrencyIso();
+    }
 }

--- a/force-app/main/default/lwc/currencyConverter/currencyConverter.js
+++ b/force-app/main/default/lwc/currencyConverter/currencyConverter.js
@@ -2,6 +2,7 @@ import { LightningElement, wire, track } from 'lwc';
 import getActiveCurrencies from '@salesforce/apex/CurrencyConverterService.getActiveCurrencies';
 import convertCurrency from '@salesforce/apex/CurrencyConverterService.convertCurrency';
 import getOrgDefaultCurrencyIso from '@salesforce/apex/CurrencyConverterService.getOrgDefaultCurrencyIso';
+import getUserDefaultCurrencyIso from '@salesforce/apex/CurrencyConverterService.getUserDefaultCurrencyIso';
 
 export default class CurrencyConverter extends LightningElement {
 	@track amount = '';
@@ -20,13 +21,19 @@ export default class CurrencyConverter extends LightningElement {
 			this.currencies = data;
 			// Set defaults after currencies load
 			if (!this.fromCurrency) {
-				getOrgDefaultCurrencyIso()
-					.then(defaultIso => {
-						this.fromCurrency = defaultIso;
-						// Do not set a default for toCurrency
+				getUserDefaultCurrencyIso()
+					.then(userIso => {
+						this.fromCurrency = userIso;
 					})
 					.catch(() => {
-						this.fromCurrency = 'USD';
+						// fallback to org default if user default fails
+						getOrgDefaultCurrencyIso()
+							.then(defaultIso => {
+								this.fromCurrency = defaultIso;
+							})
+							.catch(() => {
+								this.fromCurrency = 'USD';
+							});
 					});
 			}
 		} else if (error) {


### PR DESCRIPTION
Enhance the CurrencyConverter component to retrieve and set the user's default currency, falling back to the organization's default if necessary. Update the README to reflect these changes and provide additional component details.